### PR TITLE
feat: add scheduler switch function

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -173,6 +173,25 @@ enum quiche_cc_algorithm {
 
 // Sets the congestion control algorithm used.
 void quiche_config_set_cc_algorithm(quiche_config *config, enum quiche_cc_algorithm algo);
+// TODO: void quiche_config_set_cc_algorithm_name(quiche_config *config, const char* name);
+
+enum quiche_scheduler_type {
+    SCHE_BASIC = 0,
+    SCHE_DTP   = 1,
+    SCHE_C     = 2,
+    SCHE_DYN   = 3
+};
+// Set the scheduler type
+void quiche_config_set_scheduler_type(quiche_config *config);
+
+// Set the scheduler type by its name
+// 
+// Current Available: 
+// "Basic", "basic" for basic FIFO scheduler
+// "DTP", "Dtp", "dtp" for DTP scheduler
+// "C", "c" for C scheduler
+// "Dynamic", "dynamic", "dyn", "Dyn" for Dynamic scheduler
+void quiche_config_set_scheduler_name(quiche_config *config, const char* name);
 
 // Sets the data ack ratios
 void quiche_config_set_data_ack_ratio(quiche_config *config, uint64_t ratio);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -231,6 +231,25 @@ pub extern fn quiche_config_set_cc_algorithm(
     config.set_cc_algorithm(algo);
 }
 
+#[no_mangle]
+pub extern fn quiche_config_set_scheduler_name(
+    config: &mut Config, name: *const c_char,
+) -> c_int {
+    let name = unsafe { ffi::CStr::from_ptr(name).to_str().unwrap() };
+    match config.set_scheduler_by_name(name) {
+        Ok(_) => 0,
+
+        Err(e) => e.to_c() as c_int,
+    }
+}
+
+#[no_mangle]
+pub extern fn quiche_config_set_scheduler_type(
+    config: &mut Config, sche: scheduler::SchedulerType,
+) {
+    config.set_scheduler_type(sche);
+}
+
 // update by mc
 #[no_mangle]
 pub extern fn quiche_config_set_data_ack_ratio(

--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -659,7 +659,7 @@ impl Connection {
             .insert(stream_id, stream::Stream::new(stream_id, true));
 
         self.send_headers(conn, stream_id, headers, fin, deadline)?;
-        /// deadline
+        // deadline
         Ok(stream_id)
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -37,10 +37,12 @@ use std::time::{
     SystemTime,
 };
 
+use crate::Config;
 use crate::Error;
 use crate::Result;
 use crate::ranges;
 use crate::scheduler::{Scheduler, DynScheduler};
+use crate::scheduler;
 
 const MAX_WRITE_SIZE: usize = 1000;
 
@@ -137,17 +139,19 @@ pub struct StreamMap {
     /// min priority of app
     min_priority: Option<u64>,
 
-    scheduler: DynScheduler
+    scheduler: DynScheduler,
 }
 
 impl StreamMap {
-    pub fn new(max_streams_bidi: u64, max_streams_uni: u64) -> StreamMap {
+    pub fn new(max_streams_bidi: u64, max_streams_uni: u64, config: &Config) -> StreamMap {
         StreamMap {
             local_max_streams_bidi: max_streams_bidi,
             local_max_streams_bidi_next: max_streams_bidi,
 
             local_max_streams_uni: max_streams_uni,
             local_max_streams_uni_next: max_streams_uni,
+
+            scheduler: DynScheduler::init(config.scheduler_type),
 
             ..StreamMap::default()
         }


### PR DESCRIPTION
Add functions to configure a specific scheduler for each `Config`.

Please check the implementation of `DynScheduler`. This implementation tries to realize a configurable scheduler in runtime. However, it bases on the current `DynScheduler` struct which may lead to a misunderstanding of the function of this structure.